### PR TITLE
Add Video Output Saving Feature to Real-Time Object Detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore mp4 files
+*.mp4

--- a/real_time_detection.py
+++ b/real_time_detection.py
@@ -41,13 +41,18 @@ if __name__ == "__main__":
     cap.set(3, 640)
     cap.set(4, 480)
 
+    fourcc = cv2.VideoWriter_fourcc(*'mp4v')
+    out = cv2.VideoWriter('real_time_output_video.mp4', fourcc, 25, (640, 480))
+
     while True:
         success, img = cap.read()
         result, objectInfo = getObjects(img, 0.45, 0.2)
         cv2.imshow("Output", img)
+        out.write(img)
         key = cv2.waitKey(1)
         if key == ord('q'):
             break
 
     cap.release()
+    out.release()
     cv2.destroyAllWindows()


### PR DESCRIPTION
This PR closes #3 
Changes made:
* [x] Implemented a feature to save the processed frames as a video file named "real_time_output_video.mp4".
* [x] Integrated VideoWriter to write the processed frames into the video file during real-time object detection.
* [x] Enhanced user experience by providing an option to save the real-time object detection output.
* [x] Add gitignore to avoid adding video files to the repository.